### PR TITLE
test: drop eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/
-coverage/
-tmp/


### PR DESCRIPTION
- node_modules is [always ignored](https://eslint.org/docs/user-guide/configuring#eslintignore).
- .nyc_output contains only json, besides `npm run test-cov` is executed before `npm run eslint` in travis.
- I don't notice any tmp/ folder, might be a windows thing. If /tmp causes issue, we can always [use .gitignore](https://eslint.org/docs/user-guide/configuring#using-an-alternate-file).
`eslint --ignore-path .gitignore .`